### PR TITLE
Définition de la clé API via variable d'environnement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@
 
 Générateur d’excuses IA, personnalisable, stylé, et direct en ligne.  
 Déploie sur PythonAnywhere ou en local.
+
+## Configuration
+
+Avant de lancer l'application, définis la variable d'environnement `GORQ_API_KEY` avec ta clé Gorq :
+
+```bash
+export GORQ_API_KEY=ma-cle
+python app.py
+```

--- a/app.py
+++ b/app.py
@@ -4,7 +4,11 @@ from flask import Flask, render_template, request, jsonify
 
 app = Flask(__name__)
 
-GORQ_API_KEY = "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"
+GORQ_API_KEY = os.environ.get("GORQ_API_KEY")
+if not GORQ_API_KEY:
+    raise EnvironmentError(
+        "La clé d'API n'est pas définie. Merci de définir la variable d'environnement GORQ_API_KEY"
+    )
 
 def build_prompt(data):
     prompt = (


### PR DESCRIPTION
## Résumé
- récupération de `GORQ_API_KEY` depuis l'environnement dans `app.py`
- message d'erreur clair si la clé n'est pas définie
- ajout d'une section de configuration dans `README.md` pour expliquer comment définir `GORQ_API_KEY`

## Tests
- `pip install -r requierements.txt`
- `python app.py` (échec attendu sans variable)
- `GORQ_API_KEY=test python app.py` (lancement du serveur)


------
https://chatgpt.com/codex/tasks/task_e_685abb9445608324be7f29e1929595a1