### PR TITLE
Add optional API key file support

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,16 @@ from flask import Flask, render_template, request, jsonify
 
 app = Flask(__name__)
 
-GORQ_API_KEY = os.environ.get("GORQ_API_KEY")
+def get_api_key():
+    key_file = os.path.join(os.path.dirname(__file__), "gorq_api_key.txt")
+    if os.path.exists(key_file):
+        with open(key_file) as f:
+            key = f.read().strip()
+            if key:
+                return key
+    return os.environ.get("GORQ_API_KEY")
+
+GORQ_API_KEY = get_api_key()
 if not GORQ_API_KEY:
     raise EnvironmentError(
         "La clé d'API n'est pas définie. Merci de définir la variable d'environnement GORQ_API_KEY"

--- a/gorq_api_key.txt
+++ b/gorq_api_key.txt
@@ -1,0 +1,1 @@
+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


### PR DESCRIPTION
## Summary
- allow reading `GORQ_API_KEY` from `gorq_api_key.txt` if present
- include test API key file used for local tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac0b03fe4832497df83b61619836f