### PR TITLE
Gestion des erreurs réseau

### DIFF
--- a/app.py
+++ b/app.py
@@ -51,7 +51,10 @@ def generate_excuse(data):
         "temperature": 1.0,
         "max_tokens": 500
     }
-    resp = requests.post(url, headers=headers, json=payload, timeout=30)
+    try:
+        resp = requests.post(url, headers=headers, json=payload, timeout=30)
+    except requests.RequestException:
+        return "Erreur de connexion à l'API"
     if resp.status_code == 200:
         try:
             output = resp.json()["choices"][0]["message"]["content"]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,5 @@
 from app import build_prompt
+import requests
 
 sample_data = {
     'format': 'sms',
@@ -49,3 +50,13 @@ def test_generate_route(client, monkeypatch):
     resp = client.post('/generate', json=sample_data)
     assert resp.status_code == 200
     assert resp.get_json() == {'excuse': 'excuse générée'}
+
+
+def test_generate_route_network_error(client, monkeypatch):
+    def fake_post(*args, **kwargs):
+        raise requests.RequestException
+
+    monkeypatch.setattr('app.requests.post', fake_post)
+    resp = client.post('/generate', json=sample_data)
+    assert resp.status_code == 200
+    assert resp.get_json() == {'excuse': "Erreur de connexion à l'API"}


### PR DESCRIPTION
## Résumé
- capture `requests.RequestException` dans `generate_excuse`
- renvoie un message clair en cas d'échec réseau
- teste ce comportement en simulant une exception

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac1de43f48324a6c31a9b04919e1b