### PR TITLE
Charge variables depuis .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,14 @@ Installe d'abord les dépendances :
 pip install -r requirements.txt
 ```
 
-Avant de lancer l'application, définis la variable d'environnement `GORQ_API_KEY` avec ta clé Gorq :
+Avant de lancer l'application, place ta clé Gorq dans un fichier `.env` à la racine :
 
 ```bash
-export GORQ_API_KEY=ma-cle
+echo "GORQ_API_KEY=ma-cle" > .env
+```
+
+Puis lance simplement l'application :
+
+```bash
 python app.py
 ```

--- a/app.py
+++ b/app.py
@@ -1,16 +1,12 @@
 import os
 import requests
 from flask import Flask, render_template, request, jsonify
+from dotenv import load_dotenv
 
 app = Flask(__name__)
+load_dotenv()
 
 def get_api_key():
-    key_file = os.path.join(os.path.dirname(__file__), "gorq_api_key.txt")
-    if os.path.exists(key_file):
-        with open(key_file) as f:
-            key = f.read().strip()
-            if key:
-                return key
     return os.environ.get("GORQ_API_KEY")
 
 GORQ_API_KEY = get_api_key()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 requests
+python-dotenv


### PR DESCRIPTION
## Résumé
- ajoute `python-dotenv` aux dépendances
- charge automatiquement les variables de `.env`
- simplifie `get_api_key`
- documente l'utilisation du fichier `.env`

## Tests
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac99a85e883248ebdab1c1a629003